### PR TITLE
Connect switcher text to version switcher

### DIFF
--- a/src/switcher.ts
+++ b/src/switcher.ts
@@ -9,7 +9,7 @@ export function generateVersionSwitcher(versions: Version[], config: VersionedCo
   if (!config.versioning.switcher) return undefined;
 
   const versionSwitcher: DefaultTheme.NavItem = {
-    text: 'Switch Version',
+    text: config.switcher?.text ?? 'Switch Version',
     items: []
   }
 


### PR DESCRIPTION
The switcher text currently is not connected to the switcher and doesn't do anything. This fixes that.