### PR TITLE
Fix broken link

### DIFF
--- a/docs/guide/basic-setup.md
+++ b/docs/guide/basic-setup.md
@@ -36,7 +36,7 @@ export default defineVersionedConfig({
 }, __dirname);
 ```
 
-You can further configure this plugin by adding additional properties to the `versioning` object and within the `themeConfig` object. For a full list of configuration options, see the [Configuration Reference](/configuration/).
+You can further configure this plugin by adding additional properties to the `versioning` object and within the `themeConfig` object. For a full list of configuration options, see the [Configuration Reference](/config/).
 
 ## Localization Setup
 


### PR DESCRIPTION
The [`Configuration Reference`](https://vvp.imb11.dev/guide/basic-setup#configuration-setup) link doesn't work.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/688b935a-d2f4-4392-b678-dd8048079814">

The page redirects you to a `404`, the proper link is only [`/config/`](https://vvp.imb11.dev/config)