### PR TITLE
Fix 404 on former versions (on windows)

### DIFF
--- a/src/rewrites.ts
+++ b/src/rewrites.ts
@@ -44,7 +44,7 @@ export function generateVersionRewrites(
   for (const version of versions) {
     // Get all files recursively in the version folder
     const files = getFilesRecursively(
-      path.resolve(versionsDir, version),
+      path.posix.join(versionsDir, version),
       locales
     );
 


### PR DESCRIPTION
PR to solve the following issue:  https://github.com/IMB11/vitepress-versioning-plugin/issues/3