### PR TITLE
fix: show versioned sidebars for versioned files

### DIFF
--- a/src/sidebars.ts
+++ b/src/sidebars.ts
@@ -103,7 +103,7 @@ export function generateVersionSidebars(
 
       if (Array.isArray(sidebar)) {
         versionSidebars[
-          (locale === "root" ? "" : `/${locale}`) + `/${version}`
+          (locale === "root" ? "" : `/${locale}`) + `/${version}/`
         ] = sidebar;
       } else {
         Object.keys(sidebar).forEach((key) => {


### PR DESCRIPTION
See https://github.com/IMB11/vitepress-versioning-plugin/discussions/12

I suppose that line 111 should be changed as well, but I haven't checked that.