### PR TITLE
Fix/base url version switcher

### DIFF
--- a/src/components/VersionSwitcher.vue
+++ b/src/components/VersionSwitcher.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRouter } from "vitepress"
+import { useData, useRouter } from "vitepress"
 import { computed, ref } from 'vue'
 import VPMenuLink from 'vitepress/dist/client/theme-default/components/VPMenuLink.vue'
 import VPFlyout from 'vitepress/dist/client/theme-default/components/VPFlyout.vue'
@@ -9,12 +9,13 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+const { site } = useData();
 
 const currentVersion = computed(() => {
   let version = props.versioningPlugin.latestVersion;
 
   for (const v of props.versioningPlugin.versions) {
-    if (router.route.path.startsWith(`/${v}/`)) {
+    if (router.route.path.startsWith(`${site.value.base}${v}/`)) {
       version = v;
       break;
     }


### PR DESCRIPTION
Navbar version displayed does not correspond to the base URL version.

When selecting a navbar version, it properly redirects me to the new version page, however, the version selected on the navar resets to the default version. I suspect that is is the issue described here: #14 
This PR allows both the URL and the navbar switcher to match.

Before fix: select the 0.2.0 version properly redirects to 0.2.0, but does not reflect that on the navbar selector
![image](https://github.com/user-attachments/assets/99742627-78e5-4bdc-ab92-edb4d511f27c)

After fix, all match (URL, page selected and navbar selector)
![image](https://github.com/user-attachments/assets/53b68ab5-872b-4eb2-b562-7d5ab4b126b6)
